### PR TITLE
Compatibiliy with Windows fixing the /bin/sh problem.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 .gradle
 .idea
+.settings
+.project
+.classpath
 rbss-devops-plugin.iml
 build/
 rbss-platform-deploy-gradle-plugin.iml
+/bin/

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 }
 
 group 'io.advantageous.gradle'
-version '0.1.7'
+version '0.1.8'
 
 apply plugin: 'maven'
 apply plugin: 'signing'

--- a/src/main/groovy/io/advantageous/gradle/docker/DockerContainer.groovy
+++ b/src/main/groovy/io/advantageous/gradle/docker/DockerContainer.groovy
@@ -1,5 +1,7 @@
 package io.advantageous.gradle.docker
 
+import org.apache.tools.ant.taskdefs.condition.Os
+
 class DockerContainer {
 
     private final String name
@@ -105,14 +107,14 @@ class DockerContainer {
         }
 
         if (env.size() > 0) {
+            def delimiter = Os.isFamily(Os.FAMILY_WINDOWS) ? "" : "'";
             env.entrySet().stream().forEach { entry ->
                 builder.append(" --env=")
-                        .append("'")
+                        .append(delimiter)
                         .append(entry.key.toString().toUpperCase())
                         .append('=')
                         .append(entry.value)
-                        .append("'")
-
+                        .append(delimiter)
             }
         }
 
@@ -136,5 +138,4 @@ class DockerContainer {
 
         builder.toString()
     }
-
 }

--- a/src/main/groovy/io/advantageous/gradle/docker/DockerUtils.groovy
+++ b/src/main/groovy/io/advantageous/gradle/docker/DockerUtils.groovy
@@ -1,5 +1,7 @@
 package io.advantageous.gradle.docker
 
+import org.apache.tools.ant.taskdefs.condition.Os
+
 class DockerUtils {
 
     static Map<String, String> getDockerEnv() {
@@ -14,7 +16,7 @@ class DockerUtils {
                             .findAll { it.startsWith('export') }
                             .collect { it.replace('export', '').replace('"', '').trim() }
                             .collect { it.split('=') }
-                            .collectEntries { [it[0], it[1]] }
+                            .collectEntries { [it[0], it[1]]}
                 }
             }
         }
@@ -40,12 +42,18 @@ class DockerUtils {
         runCommand("docker", "build", "-t", dockerCoordinates(namespace, projectName, projectVersion), "build/")
     }
 
+    static prepareArgs(String command, boolean runningOnWindows) {
+        if (!runningOnWindows)
+            return ["/bin/sh", "-c", "$command"]
+        else
+            return ["cmd", "/c", "$command"]
+    }
+
     static runCommand(String command) {
-
-
         println("Running command $command")
 
-        String[] args = ["/bin/sh", "-c",  "$command"]
+        def runningOnWindows = Os.isFamily(Os.FAMILY_WINDOWS);
+        String[] args = prepareArgs(command, runningOnWindows);
 
         def stringBuilder = new StringBuilder()
         def processBuilder = new ProcessBuilder()

--- a/src/test/groovy/io/advantageous/gradle/docker/DockerContainerTest.groovy
+++ b/src/test/groovy/io/advantageous/gradle/docker/DockerContainerTest.groovy
@@ -1,12 +1,13 @@
 package io.advantageous.gradle.docker
 
+import org.apache.tools.ant.taskdefs.condition.Os
 import org.junit.Test
 import org.testng.Assert
 
 class DockerContainerTest {
 
     @Test
-    void testRunCommand() throws Exception {
+    void testRunCommand_nonWin() throws Exception {
 
         def socat = new DockerContainer("socat")
                 .containerName("docker-http")
@@ -15,7 +16,10 @@ class DockerContainerTest {
                 .image("sequenceiq/socat").env("foo":"bar")
                 .runCommand()
 
-        Assert.assertEquals(
-                "docker run -d -p 2375:2375 --volume=/var/run/docker.sock:/var/run/docker.sock --env='FOO=bar' --name=docker-http sequenceiq/socat", socat)
+        def expected = Os.isFamily(Os.FAMILY_WINDOWS) ?
+                "docker run -d -p 2375:2375 --volume=/var/run/docker.sock:/var/run/docker.sock --env=FOO=bar --name=docker-http sequenceiq/socat":
+                "docker run -d -p 2375:2375 --volume=/var/run/docker.sock:/var/run/docker.sock --env='FOO=bar' --name=docker-http sequenceiq/socat" ;
+
+        Assert.assertEquals(expected, socat)
     }
 }

--- a/src/test/groovy/io/advantageous/gradle/docker/DockerUtilsTest.groovy
+++ b/src/test/groovy/io/advantageous/gradle/docker/DockerUtilsTest.groovy
@@ -1,0 +1,24 @@
+package io.advantageous.gradle.docker
+
+import org.junit.Test
+import org.testng.Assert
+
+class DockerUtilsTest {
+    final SAMPLE = "docker run -d -p 2375:2375 --volume=/var/run/docker.sock:/var/run/docker.sock --env='FOO=bar' --name=docker-http sequenceiq/socat"
+
+    @Test
+    void prepareArgs_windows() throws Exception {
+        def actualWin = DockerUtils.prepareArgs(SAMPLE, true)
+        Assert.assertEquals("cmd", actualWin.get(0))
+        Assert.assertEquals("/c", actualWin.get(1))
+        Assert.assertEquals(SAMPLE, actualWin.get(2))
+    }
+
+    @Test
+    void prepareArgs_linux() throws Exception {
+        def actualLinux = DockerUtils.prepareArgs(SAMPLE, false)
+        Assert.assertEquals("/bin/sh", actualLinux.get(0))
+        Assert.assertEquals("-c", actualLinux.get(1))
+        Assert.assertEquals(SAMPLE, actualLinux.get(2))
+    }
+}


### PR DESCRIPTION
Earlier today I had this problem trying to run a gradle build from eclipse: it would not run `startTestDocker` because it attempted to create the process using `/bin/sh -c`, and that would work in my MINGW64, but fail in my **Eclipse.**

After I created the issue (#2), I did some investigation, fixed the problem and finally tested it in my own project. It works like a charm.

Using the gradle plugin framework, we now identify the OS (windows or not) and use that to predict if we use /bin/sh or cmd. Has been tested on a windows+eclipse machine and works.

I hope you enjoy this contrib.